### PR TITLE
Make code cleanup 

### DIFF
--- a/che-theia-java-extension/src/browser/che-ls-jdt-commands.ts
+++ b/che-theia-java-extension/src/browser/che-ls-jdt-commands.ts
@@ -10,113 +10,113 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-export const HELLO_WORLD_COMMAND = "org.eclipse.che.jdt.ls.extension.samplecommand";
+export const HELLO_WORLD_COMMAND = 'org.eclipse.che.jdt.ls.extension.samplecommand';
 export const FILE_STRUCTURE_COMMAND =
-    "org.eclipse.che.jdt.ls.extension.filestructure";
-export const TEST_DETECT_COMMAND = "che.jdt.ls.extension.detectTest";
-export const FIND_TEST_BY_CURSOR_COMMAND = "che.jdt.ls.extension.findTestByCursor";
+    'org.eclipse.che.jdt.ls.extension.filestructure';
+export const TEST_DETECT_COMMAND = 'che.jdt.ls.extension.detectTest';
+export const FIND_TEST_BY_CURSOR_COMMAND = 'che.jdt.ls.extension.findTestByCursor';
 export const FIND_TESTS_FROM_PROJECT_COMMAND =
-    "che.jdt.ls.extension.findTestFromProject";
+    'che.jdt.ls.extension.findTestFromProject';
 export const FIND_TESTS_FROM_FOLDER_COMMAND =
-    "che.jdt.ls.extension.findTestFromFolder";
+    'che.jdt.ls.extension.findTestFromFolder';
 export const FIND_TESTS_FROM_ENTRY_COMMAND =
-    "che.jdt.ls.extension.findTestFromEntry";
-export const FIND_TESTS_IN_FILE_COMMAND = "che.jdt.ls.extension.findTestInFile";
-export const RESOLVE_CLASSPATH_COMMAND = "che.jdt.ls.extension.resolveClasspath";
-export const GET_OUTPUT_DIR_COMMAND = "che.jdt.ls.extension.outputDir";
-export const GET_EFFECTIVE_POM_COMMAND = "che.jdt.ls.extension.effectivePom";
-export const GET_MAVEN_PROJECTS_COMMAND = "che.jdt.ls.extension.mavenProjects";
-export const RECOMPUTE_POM_DIAGNOSTICS = "che.jdt.ls.extension.pom.diagnostics";
+    'che.jdt.ls.extension.findTestFromEntry';
+export const FIND_TESTS_IN_FILE_COMMAND = 'che.jdt.ls.extension.findTestInFile';
+export const RESOLVE_CLASSPATH_COMMAND = 'che.jdt.ls.extension.resolveClasspath';
+export const GET_OUTPUT_DIR_COMMAND = 'che.jdt.ls.extension.outputDir';
+export const GET_EFFECTIVE_POM_COMMAND = 'che.jdt.ls.extension.effectivePom';
+export const GET_MAVEN_PROJECTS_COMMAND = 'che.jdt.ls.extension.mavenProjects';
+export const RECOMPUTE_POM_DIAGNOSTICS = 'che.jdt.ls.extension.pom.diagnostics';
 export const REIMPORT_MAVEN_PROJECTS_COMMAND =
-    "che.jdt.ls.extension.reImportMavenProject";
-export const GET_CLASS_PATH_TREE_COMMAND = "che.jdt.ls.extension.classpathTree";
+    'che.jdt.ls.extension.reImportMavenProject';
+export const GET_CLASS_PATH_TREE_COMMAND = 'che.jdt.ls.extension.classpathTree';
 
 /**
  * External Libraries
  */
 
 export const GET_EXTERNAL_LIBRARIES_COMMAND =
-    "che.jdt.ls.extension.externalLibraries";
+    'che.jdt.ls.extension.externalLibraries';
 export const GET_EXTERNAL_LIBRARIES_CHILDREN_COMMAND =
-    "che.jdt.ls.extension.externalLibrariesChildren";
-export const GET_LIBRARY_CHILDREN_COMMAND = "che.jdt.ls.extension.libraryChildren";
-export const GET_LIBRARY_ENTRY_COMMAND = "che.jdt.ls.extension.libraryEntry";
+    'che.jdt.ls.extension.externalLibrariesChildren';
+export const GET_LIBRARY_CHILDREN_COMMAND = 'che.jdt.ls.extension.libraryChildren';
+export const GET_LIBRARY_ENTRY_COMMAND = 'che.jdt.ls.extension.libraryEntry';
 
 /**
  * Debug
  */
 
 export const FIND_RESOURCES_BY_FQN =
-    "che.jdt.ls.extension.debug.findResourcesByFqn";
+    'che.jdt.ls.extension.debug.findResourcesByFqn';
 export const IDENTIFY_FQN_IN_RESOURCE =
-    "che.jdt.ls.extension.debug.identifyFqnInResource";
-export const USAGES_COMMAND = "che.jdt.ls.extension.usages";
+    'che.jdt.ls.extension.debug.identifyFqnInResource';
+export const USAGES_COMMAND = 'che.jdt.ls.extension.usages';
 
-export const UPDATE_WORKSPACE = "che.jdt.ls.extension.updateWorkspace";
+export const UPDATE_WORKSPACE = 'che.jdt.ls.extension.updateWorkspace';
 
 /**
  * Simple java project
  */
 
-export const CREATE_SIMPLE_PROJECT = "che.jdt.ls.extension.plain.createProject";
+export const CREATE_SIMPLE_PROJECT = 'che.jdt.ls.extension.plain.createProject';
 export const UPDATE_PROJECT_CLASSPATH =
-    "che.jdt.ls.extension.plain.updateClasspath";
-export const GET_SOURCE_FOLDERS = "che.jdt.ls.extension.plain.sourceFolders";
+    'che.jdt.ls.extension.plain.updateClasspath';
+export const GET_SOURCE_FOLDERS = 'che.jdt.ls.extension.plain.sourceFolders';
 
 /**
  * Navigation
  */
 
-export const FIND_IMPLEMENTERS_COMMAND = "che.jdt.ls.extension.findImplementers";
+export const FIND_IMPLEMENTERS_COMMAND = 'che.jdt.ls.extension.findImplementers';
 
 /**
  * Configuration
  */
 
 export const GET_JAVA_CORE_OPTIONS_СOMMAND =
-    "che.jdt.ls.extension.configuration.getJavaCoreOptions";
+    'che.jdt.ls.extension.configuration.getJavaCoreOptions';
 export const UPDATE_JAVA_CORE_OPTIONS_СOMMAND =
-    "che.jdt.ls.extension.configuration.updateJavaCoreOptions";
+    'che.jdt.ls.extension.configuration.updateJavaCoreOptions';
 export const GET_PREFERENCES_СOMMAND =
-    "che.jdt.ls.extension.configuration.getPreferences";
+    'che.jdt.ls.extension.configuration.getPreferences';
 export const UPDATE_PREFERENCES_СOMMAND =
-    "che.jdt.ls.extension.configuration.updatePreferences";
+    'che.jdt.ls.extension.configuration.updatePreferences';
 
 /**
  * Imports
  */
 
-export const ORGANIZE_IMPORTS = "che.jdt.ls.extension.import.organizeImports";
+export const ORGANIZE_IMPORTS = 'che.jdt.ls.extension.import.organizeImports';
 
 /**
  * Refactoring
  */
 
-export const RENAME_COMMAND = "che.jdt.ls.extension.refactoring.rename";
+export const RENAME_COMMAND = 'che.jdt.ls.extension.refactoring.rename';
 export const GET_RENAME_TYPE_COMMAND =
-    "che.jdt.ls.extension.refactoring.rename.get.type";
+    'che.jdt.ls.extension.refactoring.rename.get.type';
 export const VALIDATE_RENAMED_NAME_COMMAND =
-    "che.jdt.ls.extension.refactoring.rename.validate.new.name";
+    'che.jdt.ls.extension.refactoring.rename.validate.new.name';
 export const GET_LINKED_ELEMENTS_COMMAND =
-    "che.jdt.ls.extension.refactoring.rename.get.linked.elements";
+    'che.jdt.ls.extension.refactoring.rename.get.linked.elements';
 export const VALIDATE_MOVE_COMMAND =
-    "che.jdt.ls.extension.refactoring.move.validate";
+    'che.jdt.ls.extension.refactoring.move.validate';
 export const GET_DESTINATIONS_COMMAND =
-    "che.jdt.ls.extension.refactoring.move.get.destinations.command";
-export const MOVE_COMMAND = "che.jdt.ls.extension.refactoring.move.command";
+    'che.jdt.ls.extension.refactoring.move.get.destinations.command';
+export const MOVE_COMMAND = 'che.jdt.ls.extension.refactoring.move.command';
 export const VERIFY_MOVE_DESTINATION_COMMAND =
-    "che.jdt.ls.extension.refactoring.move.verify.destination";
+    'che.jdt.ls.extension.refactoring.move.verify.destination';
 
 /**
  * Classpath updater
  */
 
 export const CLIENT_UPDATE_PROJECTS_CLASSPATH =
-    "che.jdt.ls.extension.workspace.clientUpdateProjectsClasspath";
+    'che.jdt.ls.extension.workspace.clientUpdateProjectsClasspath';
 
 /**
  * Project updater
  */
 
 export const CLIENT_UPDATE_PROJECT =
-    "che.jdt.ls.extension.workspace.clientUpdateProject";
+    'che.jdt.ls.extension.workspace.clientUpdateProject';

--- a/che-theia-java-extension/src/browser/che-theia-java-contribution.ts
+++ b/che-theia-java-extension/src/browser/che-theia-java-contribution.ts
@@ -10,9 +10,9 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { injectable } from "inversify";
-import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from "@theia/core/lib/common";
-import { KeybindingContribution, KeybindingRegistry } from "@theia/core/lib/browser";
+import { injectable } from 'inversify';
+import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
+import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
 
 @injectable()
 export class JavaExtensionContribution implements CommandContribution, MenuContribution, KeybindingContribution {

--- a/che-theia-java-extension/src/browser/che-theia-java-frontend-module.ts
+++ b/che-theia-java-extension/src/browser/che-theia-java-frontend-module.ts
@@ -16,10 +16,10 @@ import {
     MenuContribution
 } from "@theia/core/lib/common";
 
-import { ContainerModule } from "inversify";
+import { ContainerModule } from 'inversify';
 import { KeybindingContribution, KeybindingContext } from '@theia/core/lib/browser';
 
-import "../../src/browser/styles/icons.css";
+import '../../src/browser/styles/icons.css';
 import { FileStructure } from './navigation/file-structure';
 import { FindImplementers } from './navigation/find-implementers';
 import { JavaEditorTextFocusContext } from './java-keybinding-contexts';

--- a/che-theia-java-extension/src/browser/java-keybinding-contexts.ts
+++ b/che-theia-java-extension/src/browser/java-keybinding-contexts.ts
@@ -14,9 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable } from "inversify";
-import { EditorTextFocusContext, EditorWidget } from "@theia/editor/lib/browser";
-import { JAVA_LANGUAGE_ID } from "@theia/java/lib/browser";
+import { injectable } from 'inversify';
+import { EditorTextFocusContext, EditorWidget } from '@theia/editor/lib/browser';
+import { JAVA_LANGUAGE_ID } from '@theia/java/lib/browser';
 
 export namespace JavaKeybindingContexts {
     export const javaEditorTextFocus = 'javaEditorTextFocus';

--- a/che-theia-java-extension/src/browser/navigation/file-structure.ts
+++ b/che-theia-java-extension/src/browser/navigation/file-structure.ts
@@ -10,13 +10,13 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { inject, injectable } from "inversify";
-import { QuickOpenModel, QuickOpenItem, KeybindingRegistry, Keybinding, QuickOpenService, QuickOpenMode, KeybindingContribution } from "@theia/core/lib/browser";
-import { CommandRegistry, CommandContribution, Command, MenuModelRegistry, MenuContribution } from "@theia/core";
-import { ILanguageClient, ExecuteCommandRequest, SymbolKind } from "@theia/languages/lib/browser";
-import { LanguageClientProvider } from "@theia/languages/lib/browser/language-client-provider";
-import { EditorManager, EDITOR_CONTEXT_MENU } from "@theia/editor/lib/browser";
-import { FILE_STRUCTURE_COMMAND } from "../che-ls-jdt-commands";
+import { inject, injectable } from 'inversify';
+import { QuickOpenModel, QuickOpenItem, KeybindingRegistry, Keybinding, QuickOpenService, QuickOpenMode, KeybindingContribution } from '@theia/core/lib/browser';
+import { CommandRegistry, CommandContribution, Command, MenuModelRegistry, MenuContribution } from '@theia/core';
+import { ILanguageClient, ExecuteCommandRequest, SymbolKind } from '@theia/languages/lib/browser';
+import { LanguageClientProvider } from '@theia/languages/lib/browser/language-client-provider';
+import { EditorManager, EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
+import { FILE_STRUCTURE_COMMAND } from '../che-ls-jdt-commands';
 import URI from '@theia/core/lib/common/uri';
 import { Range } from 'vscode-languageserver-types';
 
@@ -66,7 +66,7 @@ export class FileStructure implements QuickOpenModel, CommandContribution, Keybi
     /**
      * The current lookFor string input by the user.
      */
-    protected currentLookFor: string = "";
+    protected currentLookFor: string = '';
 
     private items!: QuickOpenItem[];
     private command: Command = {
@@ -77,12 +77,10 @@ export class FileStructure implements QuickOpenModel, CommandContribution, Keybi
     constructor(
         @inject(CommandRegistry) protected readonly commands: CommandRegistry,
         @inject(KeybindingRegistry) protected readonly keybindingRegistry: KeybindingRegistry,
-        @inject(KeybindingRegistry) protected readonly keybindings: KeybindingRegistry,
         @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService,
         @inject(LanguageClientProvider) protected readonly languageClientProvider: LanguageClientProvider,
         @inject(EditorManager) protected readonly editorManager: EditorManager
-    ) {
-    }
+    ) {}
 
     async open() {
         // Triggering the keyboard shortcut while the dialog is open toggles
@@ -94,14 +92,14 @@ export class FileStructure implements QuickOpenModel, CommandContribution, Keybi
             this.isOpen = true;
         }
 
-        let placeholderText = "File Structure.";
+        let placeholderText = 'File Structure.';
         const keybinding = this.getKeyCommand();
         const showOrHide = this.showInheritedMembers ? 'hide' : 'show';
         if (keybinding) {
             placeholderText += ` (Press ${keybinding} to ${showOrHide} inherited members)`;
         }
 
-        const client = await this.languageClientProvider.getLanguageClient("java");
+        const client = await this.languageClientProvider.getLanguageClient('java');
         if (client) {
             const fileStructureResponse = await this.doRequestToStructure(client);
 
@@ -115,7 +113,7 @@ export class FileStructure implements QuickOpenModel, CommandContribution, Keybi
                 placeholder: placeholderText,
                 onClose: () => {
                     this.isOpen = false;
-                    this.currentLookFor = "";
+                    this.currentLookFor = '';
                 },
             });
         }
@@ -161,7 +159,7 @@ export class FileStructure implements QuickOpenModel, CommandContribution, Keybi
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: this.command.id,
-            keybinding: "ctrlcmd+alt+o"
+            keybinding: 'ctrlcmd+alt+m'
         });
     }
 
@@ -175,7 +173,7 @@ export class FileStructure implements QuickOpenModel, CommandContribution, Keybi
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction([...EDITOR_CONTEXT_MENU, 'navigation'], {
             commandId: this.command.id,
-            label: "Navigate File Structure"
+            label: 'Navigate File Structure'
         });
     }
 
@@ -229,25 +227,25 @@ export class MemberQuickOpenItem extends QuickOpenItem {
     }
 
     getDescription(): string {
-        return "";
+        return '';
     }
 
     getIconClass() {
         switch (this.kind) {
             case SymbolKind.Interface: {
-                return "java-interface-icon file-icon";
+                return 'java-interface-icon file-icon';
             }
             case SymbolKind.Enum: {
-                return "java-enum-icon file-icon";
+                return 'java-enum-icon file-icon';
             }
             case SymbolKind.Field: {
-                return "java-field-icon file-icon";
+                return 'java-field-icon file-icon';
             }
             case SymbolKind.Method: {
-                return "java-method-icon file-icon";
+                return 'java-method-icon file-icon';
             }
             default:
-                return "java-class-icon file-icon";
+                return 'java-class-icon file-icon';
         }
     }
 

--- a/che-theia-java-extension/src/browser/navigation/find-implementers.ts
+++ b/che-theia-java-extension/src/browser/navigation/find-implementers.ts
@@ -56,7 +56,7 @@ export class FindImplementers implements QuickOpenModel, CommandContribution, Ke
     }
 
     async execute() {
-        const client = await this.languageClientProvider.getLanguageClient("java");
+        const client = await this.languageClientProvider.getLanguageClient('java');
         if (client) {
             const implementersResponse = await this.doRequestToimplementers(client);
 
@@ -91,7 +91,7 @@ export class FindImplementers implements QuickOpenModel, CommandContribution, Ke
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: this.command.id,
-            keybinding: "ctrlcmd+alt+b",
+            keybinding: 'ctrlcmd+alt+b',
             context: JavaKeybindingContexts.javaEditorTextFocus
         });
     }
@@ -103,7 +103,7 @@ export class FindImplementers implements QuickOpenModel, CommandContribution, Ke
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction([...EDITOR_CONTEXT_MENU, 'navigation'], {
             commandId: this.command.id,
-            label: "Open Implementation(s)"
+            label: 'Open Implementation(s)'
         });
     }
 
@@ -135,8 +135,8 @@ export class FindImplementers implements QuickOpenModel, CommandContribution, Ke
         }
 
         return {
-            "searchedElement": "",
-            "implementers": []
+            'searchedElement': '',
+            'implementers': []
         };
     }
 
@@ -175,13 +175,13 @@ export class ImplementerQuickOpenItem extends QuickOpenItem {
     getIconClass() {
         switch (this.kind) {
             case SymbolKind.Interface: {
-                return "java-interface-icon file-icon";
+                return 'java-interface-icon file-icon';
             }
             case SymbolKind.Enum: {
-                return "java-enum-icon file-icon";
+                return 'java-enum-icon file-icon';
             }
             default:
-                return "java-class-icon file-icon";
+                return 'java-class-icon file-icon';
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>
1. Reaplace `"`  with `'`; 
2. Change keybinding for File Structure command from `ctrl+alt+o` to `ctrl+alt+m`, because `ctrl+alt+o` is registered for  `Open...` command in Theia.   

Related issue: Changes were done during https://github.com/theia-ide/theia/issues/2849